### PR TITLE
Add spaces between icon and text for tab buttons

### DIFF
--- a/src/assets/scss/core/_tabs.scss
+++ b/src/assets/scss/core/_tabs.scss
@@ -114,6 +114,9 @@
   disabled .mat-tab-label:hover {
     color: rgba(255, 255, 255, 0.5);
   }
+  .material-icons {
+    margin: -1px 5px 0 0;
+  }
 }
 
 .mat-tab-label-active {


### PR DESCRIPTION
Here is how it now looks like
![image](https://user-images.githubusercontent.com/7910165/49430652-e0ee9300-f7ab-11e8-8ac6-ba8ad412e9eb.png)
