### PR TITLE
reuse formatted data in case of refresh.

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "karma-jasmine": "^2.0.1",
     "karma-jasmine-html-reporter": "^1.4.0",
     "maildev": "^1.0.0-rc3",
-    "mocha": "^5.2.0",
     "mocha-junit-reporter": "^1.18.0",
     "mochawesome": "^3.1.1",
     "protractor": "^5.4.1",

--- a/src/app/pages/charging-stations/charging-stations-data-source-table.ts
+++ b/src/app/pages/charging-stations/charging-stations-data-source-table.ts
@@ -64,9 +64,6 @@ export class ChargingStationsDataSource extends TableDataSource<Charger> {
       this.setNumberOfRecords(chargers.count);
       // Update page length
       this.updatePaginator();
-      // Return logs
-      this.getDataSubjet().next(chargers.result);
-      // Keep the result
       this.setData(chargers.result);
     }, (error) => {
       // Show

--- a/src/app/pages/logs/logs-data-source-table.ts
+++ b/src/app/pages/logs/logs-data-source-table.ts
@@ -67,9 +67,6 @@ export class LogsDataSource extends TableDataSource<Log> {
         }
         return log;
       });
-      // Return logs
-      this.getDataSubjet().next(logs.result);
-      // Keep the result
       this.setData(logs.result);
     }, (error) => {
       // Show

--- a/src/app/pages/tenants/tenants-data-source-table.ts
+++ b/src/app/pages/tenants/tenants-data-source-table.ts
@@ -56,9 +56,6 @@ export class TenantsDataSource extends TableDataSource<Tenant> {
       this.setNumberOfRecords(tenants.count);
       // Update Paginator
       this.updatePaginator();
-      // Notify
-      this.getDataSubjet().next(tenants.result);
-      // Set the data
       this.setData(tenants.result);
     }, (error) => {
       // Hide

--- a/src/app/pages/transactions/history/transactions-history-data-source-table.ts
+++ b/src/app/pages/transactions/history/transactions-history-data-source-table.ts
@@ -63,7 +63,6 @@ export class TransactionsHistoryDataSource extends TableDataSource<Transaction> 
         this.spinnerService.hide();
         this.setNumberOfRecords(transactions.count);
         this.updatePaginator();
-        this.getDataSubjet().next(transactions.result);
         this.setData(transactions.result);
       }, (error) => {
         this.spinnerService.hide();
@@ -75,6 +74,10 @@ export class TransactionsHistoryDataSource extends TableDataSource<Transaction> 
   public getTableDef(): TableDef {
     return {
       class: 'table-list-under-tabs',
+      rowSelection: {
+        enabled: true,
+        multiple: true
+      },
       search: {
         enabled: true
       }

--- a/src/app/pages/transactions/in-progress/transactions-in-progress-data-source-table.ts
+++ b/src/app/pages/transactions/in-progress/transactions-in-progress-data-source-table.ts
@@ -59,7 +59,6 @@ export class TransactionsInProgressDataSource extends TableDataSource<Transactio
         this.spinnerService.hide();
         this.setNumberOfRecords(transactions.count);
         this.updatePaginator();
-        this.getDataSubjet().next(transactions.result);
         this.setData(transactions.result);
       }, (error) => {
         this.spinnerService.hide();

--- a/src/app/pages/users/user/user-sites-data-source-table.ts
+++ b/src/app/pages/users/user/user-sites-data-source-table.ts
@@ -35,11 +35,6 @@ export class UserSitesDataSource extends TableDataSource<Site> {
         this.getPaging(), this.getOrdering()).subscribe((sites) => {
         // Set number of records
         this.setNumberOfRecords(sites.count);
-        // Update page length (number of sites is in User)
-        this.updatePaginator();
-        // Return sites
-        this.getDataSubjet().next(sites.result);
-        // Keep it
         this.setData(sites.result);
       }, (error) => {
         // No longer exists!
@@ -47,10 +42,8 @@ export class UserSitesDataSource extends TableDataSource<Site> {
           this.translateService.instant('general.error_backend'));
       });
     } else {
-      // Update page length
       this.updatePaginator();
-      // Return sites
-      this.getDataSubjet().next([]);
+        this.setData([]);
     }
   }
 

--- a/src/app/pages/users/users-data-source-table.ts
+++ b/src/app/pages/users/users-data-source-table.ts
@@ -74,9 +74,6 @@ export class UsersDataSource extends TableDataSource<User> {
       this.setNumberOfRecords(users.count);
       // Update Paginator
       this.updatePaginator();
-      // Notify
-      this.getDataSubjet().next(users.result);
-      // Set the data
       this.setData(users.result);
     }, (error) => {
       // Hide

--- a/src/app/shared/dialogs/chargers/chargers-data-source-table.ts
+++ b/src/app/shared/dialogs/chargers/chargers-data-source-table.ts
@@ -24,9 +24,6 @@ export class ChargersDataSource extends DialogTableDataSource<Charger> {
       this.setNumberOfRecords(chargers.count);
       // Update page length (number of sites is in User)
       this.updatePaginator();
-      // Return chargers
-      this.getDataSubjet().next(chargers.result);
-      // Keep it
       this.setData(chargers.result);
     }, (error) => {
       // No longer exists!

--- a/src/app/shared/dialogs/sites/sites-data-source-table.ts
+++ b/src/app/shared/dialogs/sites/sites-data-source-table.ts
@@ -23,9 +23,6 @@ export class SitesDataSource extends DialogTableDataSource<Site> {
       this.setNumberOfRecords(sites.count);
       // Update page length (number of sites is in User)
       this.updatePaginator();
-      // Return sites
-      this.getDataSubjet().next(sites.result);
-      // Keep it
       this.setData(sites.result);
     }, (error) => {
       // No longer exists!

--- a/src/app/shared/dialogs/sites/sites-filter-data-source-table.ts
+++ b/src/app/shared/dialogs/sites/sites-filter-data-source-table.ts
@@ -23,9 +23,6 @@ export class SitesFilterDataSource extends DialogTableDataSource<Site> {
       this.setNumberOfRecords(sites.count);
       // Update page length (number of sites is in User)
       this.updatePaginator();
-      // Return sites
-      this.getDataSubjet().next(sites.result);
-      // Keep it
       this.setData(sites.result);
     }, (error) => {
       // No longer exists!

--- a/src/app/shared/dialogs/users/users-data-source-table.ts
+++ b/src/app/shared/dialogs/users/users-data-source-table.ts
@@ -23,9 +23,6 @@ export class UsersDataSource extends DialogTableDataSource<User> {
       this.setNumberOfRecords(users.count);
       // Update page length (number of sites is in User)
       this.updatePaginator();
-      // Return sites
-      this.getDataSubjet().next(users.result);
-      // Keep it
       this.setData(users.result);
     }, (error) => {
       // No longer exists!

--- a/src/app/shared/table/table-data-source.ts
+++ b/src/app/shared/table/table-data-source.ts
@@ -4,9 +4,12 @@ import {MatPaginator, MatSort} from '@angular/material';
 import {CollectionViewer, DataSource, SelectionModel} from '@angular/cdk/collections';
 import {Ordering, Paging, SubjectInfo, TableActionDef, TableColumnDef, TableDef, TableFilterDef} from '../../common.types';
 import {Constants} from '../../utils/Constants';
+import {Utils} from '../../utils/Utils';
+
+import * as _ from 'lodash';
 
 export abstract class TableDataSource<T> implements DataSource<T> {
-  private dataSubject = new BehaviorSubject<T[]>([]);
+  private dataSubject = new BehaviorSubject<any[]>([]);
   private searchInput: ElementRef;
   private paginator: MatPaginator;
   private sort: MatSort;
@@ -17,10 +20,13 @@ export abstract class TableDataSource<T> implements DataSource<T> {
   private rowActionsDef: TableActionDef[];
   private filtersDef: TableFilterDef[];
   private selectionModel: SelectionModel<T>;
-  private data: T[] = [];
+  private data: any[] = [];
+  private formattedData = [];
+  private locale;
   private dataChangeSubscription: Subscription;
   private staticFilters = [];
   private pollingInterval: number;
+  private i = 0;
 
   public setPollingInterval(pollingInterval: number) {
     this.pollingInterval = pollingInterval;
@@ -183,10 +189,11 @@ export abstract class TableDataSource<T> implements DataSource<T> {
   }
 
   public setData(data: T[]) {
-    this.data = data;
+    this.refreshData(data);
+    this.dataSubject.next(this.formattedData);
   }
 
-  public getData(): T[] {
+  public getData(): any[] {
     return this.data;
   }
 
@@ -356,6 +363,43 @@ export abstract class TableDataSource<T> implements DataSource<T> {
 
   abstract loadData();
 
+  refreshData(freshData: any[]) {
+    const freshFormattedData = [];
+    freshData.forEach((freshRow) => {
+      const index = this.data.findIndex(row => row.id === freshRow.id);
+      if (index !== -1) {
+        if (_.isEqual(this.data[index], freshRow)) {
+          freshFormattedData.push(this.formattedData[index]);
+        } else {
+          freshFormattedData.push(this._formatRow(freshRow));
+        }
+      } else {
+        freshFormattedData.push(this._formatRow(freshRow));
+      }
+    });
+    this.formattedData = freshFormattedData;
+    this.data = freshData;
+  }
+
+  _formatRow(row): any[] {
+    const formattedRow = [];
+    this.getTableColumnDefs().forEach((columnDef) => {
+      formattedRow.push(this._buildCellValue(row, columnDef));
+    });
+    formattedRow['data'] = row;
+    return formattedRow;
+  }
+
+  changeLocaleTo(locale: string) {
+    if (this.locale !== locale) {
+      this.locale = locale;
+      this.formattedData = [];
+      const toRefresh = this.data;
+      this.data = [];
+      this.refreshData(toRefresh);
+    }
+  }
+
   private _checkInitialized(): any {
     // Check
     if (!this.tableDef) {
@@ -400,5 +444,69 @@ export abstract class TableDataSource<T> implements DataSource<T> {
         }
       });
     }
+  }
+
+  private findPropertyValue(columnDef, propertyName, source) {
+    let propertyValue = null;
+    propertyValue = source[propertyName];
+    if (propertyName.indexOf('.') > 0) {
+      propertyValue = source;
+      propertyName.split('.').forEach((key) => {
+          if (propertyValue.hasOwnProperty(key)) {
+            propertyValue = propertyValue[key];
+          } else if (columnDef.defaultValue) {
+            propertyValue = columnDef.defaultValue;
+          } else {
+            switch (columnDef.type) {
+              case 'number':
+              case 'float':
+                propertyValue = 0;
+                break;
+              default:
+                propertyValue = '';
+                break;
+            }
+          }
+        }
+      );
+    }
+    return propertyValue;
+  }
+
+  private _buildCellValue(row: any, columnDef: TableColumnDef) {
+    let propertyValue = this.findPropertyValue(columnDef, columnDef.id, row);
+
+    const additionalProperties = [];
+    if (columnDef.additionalIds) {
+      columnDef.additionalIds.forEach(propertyName => {
+          additionalProperties.push(this.findPropertyValue(columnDef, propertyName, row));
+        }
+      );
+    }
+    // Type?
+    switch (columnDef.type) {
+      // Date
+      case 'date':
+        propertyValue = Utils.convertToDate(propertyValue);
+        break;
+      // Integer
+      case 'integer':
+        propertyValue = Utils.convertToInteger(propertyValue);
+        break;
+      // Float
+      case 'float':
+        propertyValue = Utils.convertToFloat(propertyValue);
+        break;
+    }
+
+    if (columnDef.formatter) {
+      if (additionalProperties.length > 0) {
+        propertyValue = columnDef.formatter(propertyValue, row, ...additionalProperties);
+      } else {
+        propertyValue = columnDef.formatter(propertyValue, row);
+      }
+    }
+    // Return the property
+    return `${propertyValue ? propertyValue : ''}`;
   }
 }

--- a/src/app/shared/table/table.component.html
+++ b/src/app/shared/table/table.component.html
@@ -119,12 +119,12 @@
 
         <ng-container *ngIf="columnDef.isAngularComponent">
           <td mat-cell [class]="(columnDef.class ? columnDef.class : (columnDef.dynamicClass ? columnDef.dynamicClass(row) : ''))" *matCellDef="let row">
-              <app-cell-component-container [row]="row" [columnDef]="columnDef"></app-cell-component-container>
+              <app-cell-component-container [row]="row['data']" [columnDef]="columnDef"></app-cell-component-container>
           </td>
         </ng-container>
         <ng-container *ngIf="!columnDef.isAngularComponent">
             <td mat-cell [class]="(columnDef.class ? columnDef.class : (columnDef.dynamicClass ? columnDef.dynamicClass(row) : ''))" *matCellDef="let row"
-            [innerHtml]="buildCellValue(row, columnDef) | translate" >
+             >{{row[i] | translate}}
           </td>
         </ng-container>
         <td [hidden]="!dataSource.isFooterEnabled()" mat-footer-cell *matFooterCellDef>
@@ -138,9 +138,9 @@
           class="material-icons">keyboard_arrow_right</i>
         </th>
         <td mat-cell class="col-3em details-column-row" *matCellDef="let row">
-          <i *ngIf="dataSource.hasRowDetailsHideShowField() ? row[tableDef.rowDetails.hideShowField] : true"
+          <i *ngIf="dataSource.hasRowDetailsHideShowField() ? row['data'][tableDef.rowDetails.hideShowField] : true"
              class="material-icons"
-             (click)="showHideDetailsClicked(row)">{{row.isExpanded ? 'keyboard_arrow_down' :
+             (click)="showHideDetailsClicked(row['data'])">{{row['data'].isExpanded ? 'keyboard_arrow_down' :
             'keyboard_arrow_right'}}</i>
         </td>
         <td [hidden]="!dataSource.isFooterEnabled()" mat-footer-cell *matFooterCellDef></td>
@@ -149,9 +149,9 @@
       <!-- Detailed Column - The detail row is made up of this one column that spans across all columns -->
       <ng-container matColumnDef="rowDetails">
         <td mat-cell *matCellDef="let rowDetail" [attr.colspan]="columns.length">
-          <div class="element-details" [@detailExpand]="(rowDetail.isExpanded ? 'expanded' : 'collapsed')">
-            <ng-container *ngIf="tableDef.rowDetails && !tableDef.rowDetails.isDetailComponent && rowDetail[tableDef.rowDetails.detailsField]">
-              <div [innerHtml]="(tableDef.rowDetails ? rowDetail[tableDef.rowDetails.detailsField] : '')">
+          <div class="element-details" [@detailExpand]="(rowDetail['data'].isExpanded ? 'expanded' : 'collapsed')">
+            <ng-container *ngIf="tableDef.rowDetails && !tableDef.rowDetails.isDetailComponent && rowDetail['data'][tableDef.rowDetails.detailsField]">
+              <div [innerHtml]="(tableDef.rowDetails ? rowDetail['data'][tableDef.rowDetails.detailsField] : '')">
               ...
               </div>
             </ng-container>
@@ -170,7 +170,7 @@
         <td mat-cell *matCellDef="let actionCell" class="text-center">
           <a *ngFor="let rowAction of dataSource.getTableRowActions()"
              [class]="(rowAction.class ? rowAction.class : '') + ' btn-group btn btn-link btn-info btn-just-icon'"
-             (click)="rowActionTriggered(rowAction, actionCell)"><i class="material-icons">{{rowAction.icon}}</i></a>
+             (click)="rowActionTriggered(rowAction, actionCell['data'])"><i class="material-icons">{{rowAction.icon}}</i></a>
         </td>
         <td [hidden]="!dataSource.isFooterEnabled()" mat-footer-cell *matFooterCellDef></td>
       </ng-container>


### PR DESCRIPTION
✅[PROD BUILD PASSED]✅ 

Example on transaction history page formatting performance: 

first table formatting of 9 rows:
* duration: 39ms
* skippedRows: 0
* addedRows: 9
* updatedRows: 0

use refresh button:
* duration: 2ms
* skippedRows: 9
* addedRows: 0
* updatedRows: 0

select 500 rows:
* duration: 1352ms
* skippedRows: 9
* addedRows: 491
* updatedRows: 0

refresh same page:
* duration: 26ms
* skippedRows: 500
* addedRows: 0
* updatedRows: 0
