### PR TITLE
Paginator reset fix

### DIFF
--- a/src/app/shared/table/table.component.ts
+++ b/src/app/shared/table/table.component.ts
@@ -209,6 +209,10 @@ export class TableComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   public resetDialogTableFilter(filterDef: TableFilterDef) {
+    // Reset paginator if field is not empty
+    if (filterDef.currentValue !== null) {
+      this.paginator.pageIndex = 0;
+    }
     filterDef.currentValue = null;
     this.dataSource.filterChanged(filterDef)
   }
@@ -227,6 +231,8 @@ export class TableComponent implements OnInit, AfterViewInit, OnDestroy {
     dialogRef.afterClosed().subscribe(data => {
       if (data) {
         filterDef.currentValue = data;
+        // Reset paginator
+        this.paginator.pageIndex = 0;
         this.dataSource.filterChanged(filterDef)
       }
     });


### PR DESCRIPTION
Fixes #225 

Paginator now resets when filter changes (but not when clicking on the 'clear filter' button when no filter is applied)