### PR TITLE
Fix padding for toolbar in cards

### DIFF
--- a/src/assets/scss/dashboard/_cards.scss
+++ b/src/assets/scss/dashboard/_cards.scss
@@ -27,6 +27,21 @@
   .card-body {
     padding: $padding-card-body-y 20px;
     position: relative;
+    & .mat-toolbar {
+      padding-left: 0px !important;
+      padding-right: 0px !important;
+    }
+    & > .mat-toolbar, .mat-toolbar-row {
+      padding-left: 0px !important;
+      padding-right: 0px !important;
+      > button:first-child {
+        margin-left: 0px;
+      }
+      > button:last-child {
+        margin-right: 0px;
+      }
+    }
+
   }
 
   .card-logo {


### PR DESCRIPTION
#238 
Just changed the CSS for card-body to adress all mat-toolbar/mat-toolbar-row inside and remove left/right padding
And remove first and last button margin.

You can close the branch if merge is validated