### PR TITLE
UX > Fix : Call Big Spinner when resetting filters

### DIFF
--- a/src/app/shared/table/table-data-source.ts
+++ b/src/app/shared/table/table-data-source.ts
@@ -355,7 +355,7 @@ export abstract class TableDataSource<T> implements DataSource<T> {
       case 'reset_filters':
         this.setSearchValue('');
         this.resetFilters();
-        this.loadData(true);
+        this.loadData(false);
         break;
     }
   }


### PR DESCRIPTION
#282 

* Big Spinner is now called when resetting filters