### PR TITLE
UX > Filter Reset Button should not appear alongside a lone search field

### DIFF
--- a/src/app/shared/table/table-data-source.ts
+++ b/src/app/shared/table/table-data-source.ts
@@ -272,8 +272,7 @@ export abstract class TableDataSource<T> implements DataSource<T> {
 
   public getTableActionsDef(): TableActionDef[] {
     // Return default
-    if ((this.filtersDef && this.filtersDef.length > 0) ||
-        (this.tableDef && this.tableDef.search && this.tableDef.search.enabled)) {
+    if (this.filtersDef && this.filtersDef.length > 0) {
       return [
         new TableResetFiltersAction().getActionDef()
       ];


### PR DESCRIPTION
#309 

* The reset filter button now only appears when there are filters present, excluding the search field