### PR TITLE
Transaction > Chart: Always fix the 'y' axis to 0

### DIFF
--- a/src/app/shared/component/transaction-chart/consumption-chart.component.ts
+++ b/src/app/shared/component/transaction-chart/consumption-chart.component.ts
@@ -106,6 +106,13 @@ export class ConsumptionChartComponent implements OnInit {
       ...this.formatLineColor(this.colors[0]),
       label: this.translateService.instant('transactions.graph.power')
     });
+    this.options.scales.yAxes.push({
+      id: 'power',
+      ticks: {
+        callback: (value, index, values) => value / 1000.0,
+        min: 0
+      }
+    });
     if (this.consumptions.find(c => c.stateOfCharge !== undefined)) {
       this.data.datasets.push({
         name: 'stateOfCharge',


### PR DESCRIPTION
#429 

The origin of the Y-axis in the consumption chart is now fixed to 0