### PR TITLE
#428-Connector-Type

### DIFF
--- a/src/app/pages/charging-stations/charging-station-settings/charger-parameters/charging-station-parameters.html
+++ b/src/app/pages/charging-stations/charging-station-settings/charger-parameters/charging-station-parameters.html
@@ -114,7 +114,7 @@
                                         <mat-select placeholder="{{'chargers.connector_type' | translate}}"
                                             [formControlName]="'connectorType' + connector.connectorId" required value=connect>
                                             <mat-select-trigger>
-                                                <mat-icon [svgIcon]="formGroup.controls['connectorType' + connector.connectorId].value"></mat-icon><span>{{formGroup.controls['connectorType' + connector.connectorId].value | appConnectorType:false | translate}}</span>
+                                                <mat-icon [svgIcon]="formGroup.controls['connectorType' + connector.connectorId].value" style="padding-bottom: 3px;"></mat-icon><span>{{formGroup.controls['connectorType' + connector.connectorId].value | appConnectorType:false | translate}}</span>
                                             </mat-select-trigger>
                                             <mat-option *ngFor="let type of connectorTypeMap" [value]="type.key" class="connector-type-select-option">
                                                 <mat-icon [svgIcon]="type.key"></mat-icon><span>{{type.description | translate}}</span>


### PR DESCRIPTION
Serge,

Le panning fonctionne sur les connecteurs sauvés 
![image](https://user-images.githubusercontent.com/48201428/56669674-cd3bbe80-66b1-11e9-90c4-3b112249c00d.png)
Par contre cela ne fonctionne pas quand on créé le connecteur la première fois 
![image](https://user-images.githubusercontent.com/48201428/56669836-0f650000-66b2-11e9-99db-c7aa38fb3f98.png)

Je ne comprends pas vraiment pourquoi le style ne s'applique pas.