### PR TITLE
Charger > Edit > OCPP Params: Scroll bar should not appear

### DIFF
--- a/src/app/pages/charging-stations/charging-station-settings/charger-parameters/charging-station-parameters.html
+++ b/src/app/pages/charging-stations/charging-station-settings/charger-parameters/charging-station-parameters.html
@@ -1,5 +1,5 @@
 <div class="main-content">
-    <mat-dialog-content class="charger-dialog-component">
+    <mat-dialog-content class="charger-param-component">
     <!--<div class="container-fluid">-->
         <form class="form" [formGroup]="formGroup">
             <div class="row">

--- a/src/app/pages/charging-stations/charging-station-settings/ocpp-parameters/charging-station-ocpp-parameters.html
+++ b/src/app/pages/charging-stations/charging-station-settings/ocpp-parameters/charging-station-ocpp-parameters.html
@@ -8,7 +8,7 @@
   <div class="d-flex-row">
     <form class="form" [formGroup]="formGroup" class="w-100">
       <div class="table-responsive flex-grow-1">
-        <mat-dialog-content class="charger-dialog-component">
+        <mat-dialog-content class="ocpp-param-component">
           <table class="mat-table d-flex">
             <tbody class="w-100">
               <tr *ngFor="let item of chargerConfiguration" class="mat-row" role="row">

--- a/src/app/pages/charging-stations/charging-station-settings/properties/charging-station-properties.html
+++ b/src/app/pages/charging-stations/charging-station-settings/properties/charging-station-properties.html
@@ -1,6 +1,6 @@
 <!-- <div class="main-content"> -->
   <div class="table-responsive-md flex-grow-1">
-    <mat-dialog-content class="charger-dialog-component">
+    <mat-dialog-content class="charger-properties-component">
       <table class="mat-table" role="grid">
         <tbody role="rowgroup">
           <ng-container *ngFor="let item of displayedProperties" >

--- a/src/app/pages/charging-stations/charging-stations-list/charging-stations-list-data-source-table.ts
+++ b/src/app/pages/charging-stations/charging-stations-list/charging-stations-list-data-source-table.ts
@@ -421,7 +421,7 @@ export class ChargingStationsListDataSource extends TableDataSource<Charger> {
     const dialogConfig = new MatDialogConfig();
     dialogConfig.minWidth = '80vw';
     dialogConfig.minHeight = '60vh';
-    dialogConfig.height = '80vh';
+    dialogConfig.height = '90vh';
     dialogConfig.panelClass = 'transparent-dialog-container';
     if (chargingStation) {
       dialogConfig.data = chargingStation;

--- a/src/assets/scss/views/chargers/_charging-station.scss
+++ b/src/assets/scss/views/chargers/_charging-station.scss
@@ -22,6 +22,14 @@
     font-family: none !important; // Need to be deactivate to display properly SVG icons
 }
 
-.charger-dialog-component {
-    max-height: 55vh !important;
+.charger-param-component {
+    max-height: 74vh !important;
+}
+
+.charger-prop-component {
+    max-height: 80vh !important;
+}
+
+.ocpp-param-component {
+    max-height: 69vh !important;
 }


### PR DESCRIPTION
#281 

Augmented size of dialog to 90% of viewport and augmented and differentiated sizes of all tabs.
This prevents scroll bar appearing at normal resolutions and let the tabs take as much space as possible.