### PR TITLE
Make package-lock.json lockable.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+package-lock.json lockable


### PR DESCRIPTION
This should prevent users to modify it without taking a lock on it.

Signed-off-by: Jerome Benoit <jerome.benoit@sap.com>