### PR TITLE
Move click event to mat-icon instead of td (td is always present, mat-icon only if there is some details to show)

### DIFF
--- a/src/app/shared/table/table.component.html
+++ b/src/app/shared/table/table.component.html
@@ -176,9 +176,10 @@
           </td>
           <!-- Detail Cell -->
           <td *ngIf="dataSource.tableDef.rowDetails && dataSource.tableDef.rowDetails.enabled"
-              (click)="showHideDetailsClicked(row)" class="col-3em details-column-row">
+              class="col-3em details-column-row">
             <mat-icon
-              *ngIf="dataSource.tableDef.rowDetails && dataSource.tableDef.rowDetails.showDetailsField ? row[dataSource.tableDef.rowDetails.showDetailsField] : true">
+              *ngIf="dataSource.tableDef.rowDetails && dataSource.tableDef.rowDetails.showDetailsField ? row[dataSource.tableDef.rowDetails.showDetailsField] : true"
+              (click)="showHideDetailsClicked(row)">
               {{row.isExpanded ? "expand_more" : "chevron_right"}}
             </mat-icon>
           </td>


### PR DESCRIPTION
Move click event to mat-icon instead of td (td is always present, mat-icon only if there is some details to show)

found by https://github.com/LucasBrazi06/ev-server/issues/631