### PR TITLE
Made config file loading synchronous

### DIFF
--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -9,10 +9,8 @@ export class ConfigService {
     private http: HttpClient) {
   }
 
-  public load() {
-    this.http.get('/assets/config.json').subscribe((data) => {
-      this._config = data;
-    });
+  public async load() {
+    this._config = await this.http.get('/assets/config.json').toPromise();
   }
 
   public getCentralSystemServer() {


### PR DESCRIPTION
I experienced a bug using Firefox (70.0.1) about configuration file loading.
As it loads in a asynchronous function, it happens that the configuration file is not loaded as fast as wanted, causing a total Dashboard crash.
Making the loading synchronous fixes it.