### PR TITLE
#737-Information/Error-window-stays

### DIFF
--- a/src/app/services/message.service.ts
+++ b/src/app/services/message.service.ts
@@ -61,15 +61,15 @@ export class MessageService {
         title,
         message: this.translateService.instant(message, params),
       }, {
-        type,
-        delay: 3000,
-        timer: 1500,
+        type: type,
+        delay: 2000,
+        timer: 1000,
         allow_dismiss: true,
         placement: {
-          from,
-          align,
+          from: from,
+          align: align,
         },
-        z_index: 10000,
+        z_index: 1031,
         template: this.messageTemplate,
       },
     );


### PR DESCRIPTION
Cela aide un peu. La première notification prend plus de temps que les suivantes; je ne sais pas pourquoi.

Sur certains forums ils recommandent d'utiliser Material et pas bootstrap pour les notifications.

Le "dismiss" ne semble pas fonctionner sur FIREFOX.