### PR TITLE
Replaced hasOwnProperty everywhere

### DIFF
--- a/src/app/pages/charging-stations/charging-station/properties/charging-station-properties.component.ts
+++ b/src/app/pages/charging-stations/charging-station/properties/charging-station-properties.component.ts
@@ -2,6 +2,7 @@ import { Component, Injectable, Input, OnInit } from '@angular/core';
 import { ChargingStation, ChargingStationCapabilities, OcppAdvancedCommands } from 'app/types/ChargingStation';
 import { KeyValue } from 'app/types/GlobalType';
 import { AppDatePipe } from '../../../../shared/formatters/app-date.pipe';
+import { Utils } from '../../../../utils/Utils';
 
 export interface PropertyDisplay {
   key: string;
@@ -42,7 +43,7 @@ export class ChargingStationPropertiesComponent implements OnInit {
         if (capabilities) {
           const formatterValues: string[] = [];
           for (const key in capabilities) {
-            if (capabilities.hasOwnProperty(key)) {
+            if (Utils.objectHasProperty(capabilities, key)) {
               // @ts-ignore
               formatterValues.push(`${key}: ${capabilities[key]}`);
             }

--- a/src/app/pages/tenants/tenant/tenant.component.ts
+++ b/src/app/pages/tenants/tenant/tenant.component.ts
@@ -178,7 +178,7 @@ export class TenantComponent implements OnInit {
     let buildingActive = false;
 
     for (const component in tenant.components) {
-      if (tenant.components.hasOwnProperty(component)) {
+      if (Utils.objectHasProperty(tenant.components, component)) {
         if (!tenant.components[component].active) {
           tenant.components[component].type = null;
         }

--- a/src/app/pages/transactions/history/transactions-history-table-data-source.ts
+++ b/src/app/pages/transactions/history/transactions-history-table-data-source.ts
@@ -257,10 +257,7 @@ export class TransactionsHistoryTableDataSource extends TableDataSource<Transact
       case ButtonAction.DELETE:
         return this.isAdmin;
       case TransactionButtonAction.REFUND:
-        if (transaction.hasOwnProperty('refund')) {
-          return false;
-        }
-        return true;
+        return !Utils.objectHasProperty(transaction, 'refund');
       default:
         return true;
     }

--- a/src/app/pages/users/user/user.component.ts
+++ b/src/app/pages/users/user/user.component.ts
@@ -199,11 +199,11 @@ export class UserComponent extends AbstractTabComponent implements OnInit {
         ])),
       phone: new FormControl('',
         Validators.compose([
-          Users.validatePhone
+          Users.validatePhone,
         ])),
       mobile: new FormControl('',
         Validators.compose([
-          Users.validatePhone
+          Users.validatePhone,
         ])),
       iNumber: new FormControl('',
         Validators.compose([
@@ -443,80 +443,80 @@ export class UserComponent extends AbstractTabComponent implements OnInit {
       if (user.tags) {
         this.userTagsTableDataSource.setContent(user.tags);
       }
-      if (user.hasOwnProperty('notificationsActive')) {
+      if (Utils.objectHasProperty(user, 'notificationsActive')) {
         this.formGroup.controls.notificationsActive.setValue(user.notificationsActive);
       }
-      if (user.notifications && user.notifications.hasOwnProperty('sendSessionStarted')) {
+      if (user.notifications && Utils.objectHasProperty(user.notifications, 'sendSessionStarted')) {
         this.notifications.controls.sendSessionStarted.setValue(user.notifications.sendSessionStarted);
       } else {
         this.notifications.controls.sendSessionStarted.setValue(false);
       }
-      if (user.notifications && user.notifications.hasOwnProperty('sendOptimalChargeReached')) {
+      if (user.notifications && Utils.objectHasProperty(user.notifications, 'sendOptimalChargeReached')) {
         this.notifications.controls.sendOptimalChargeReached.setValue(user.notifications.sendOptimalChargeReached);
       } else {
         this.notifications.controls.sendOptimalChargeReached.setValue(false);
       }
-      if (user.notifications && user.notifications.hasOwnProperty('sendEndOfCharge')) {
+      if (user.notifications && Utils.objectHasProperty(user.notifications, 'sendEndOfCharge')) {
         this.notifications.controls.sendEndOfCharge.setValue(user.notifications.sendEndOfCharge);
       } else {
         this.notifications.controls.sendEndOfCharge.setValue(false);
       }
-      if (user.notifications && user.notifications.hasOwnProperty('sendEndOfSession')) {
+      if (user.notifications && Utils.objectHasProperty(user.notifications, 'sendEndOfSession')) {
         this.notifications.controls.sendEndOfSession.setValue(user.notifications.sendEndOfSession);
       } else {
         this.notifications.controls.sendEndOfSession.setValue(false);
       }
-      if (user.notifications && user.notifications.hasOwnProperty('sendUserAccountStatusChanged')) {
+      if (user.notifications && Utils.objectHasProperty(user.notifications, 'sendUserAccountStatusChanged')) {
         this.notifications.controls.sendUserAccountStatusChanged.setValue(user.notifications.sendUserAccountStatusChanged);
       } else {
         this.notifications.controls.sendUserAccountStatusChanged.setValue(false);
       }
-      if (user.notifications && user.notifications.hasOwnProperty('sendUnknownUserBadged')) {
+      if (user.notifications && Utils.objectHasProperty(user.notifications, 'sendUnknownUserBadged')) {
         this.notifications.controls.sendUnknownUserBadged.setValue(user.notifications.sendUnknownUserBadged);
       } else {
         this.notifications.controls.sendUnknownUserBadged.setValue(false);
       }
-      if (user.notifications && user.notifications.hasOwnProperty('sendChargingStationStatusError')) {
+      if (user.notifications && Utils.objectHasProperty(user.notifications, 'sendChargingStationStatusError')) {
         this.notifications.controls.sendChargingStationStatusError.setValue(user.notifications.sendChargingStationStatusError);
       } else {
         this.notifications.controls.sendChargingStationStatusError.setValue(false);
       }
-      if (user.notifications && user.notifications.hasOwnProperty('sendChargingStationRegistered')) {
+      if (user.notifications && Utils.objectHasProperty(user.notifications, 'sendChargingStationRegistered')) {
         this.notifications.controls.sendChargingStationRegistered.setValue(user.notifications.sendChargingStationRegistered);
       } else {
         this.notifications.controls.sendChargingStationRegistered.setValue(false);
       }
-      if (user.notifications && user.notifications.hasOwnProperty('sendOfflineChargingStations')) {
+      if (user.notifications && Utils.objectHasProperty(user.notifications, 'sendOfflineChargingStations')) {
         this.notifications.controls.sendOfflineChargingStations.setValue(user.notifications.sendOfflineChargingStations);
       } else {
         this.notifications.controls.sendOfflineChargingStations.setValue(false);
       }
-      if (user.notifications && user.notifications.hasOwnProperty('sendOcpiPatchStatusError')) {
+      if (user.notifications && Utils.objectHasProperty(user.notifications, 'sendOcpiPatchStatusError')) {
         this.notifications.controls.sendOcpiPatchStatusError.setValue(user.notifications.sendOcpiPatchStatusError);
       } else {
         this.notifications.controls.sendOcpiPatchStatusError.setValue(false);
       }
-      if (user.notifications && user.notifications.hasOwnProperty('sendPreparingSessionNotStarted')) {
+      if (user.notifications && Utils.objectHasProperty(user.notifications, 'sendPreparingSessionNotStarted')) {
         this.notifications.controls.sendPreparingSessionNotStarted.setValue(user.notifications.sendPreparingSessionNotStarted);
       } else {
         this.notifications.controls.sendPreparingSessionNotStarted.setValue(false);
       }
-      if (user.notifications && user.notifications.hasOwnProperty('sendSmtpAuthError')) {
+      if (user.notifications && Utils.objectHasProperty(user.notifications, 'sendSmtpAuthError')) {
         this.notifications.controls.sendSmtpAuthError.setValue(user.notifications.sendSmtpAuthError);
       } else {
         this.notifications.controls.sendSmtpAuthError.setValue(false);
       }
-      if (user.notifications && user.notifications.hasOwnProperty('sendBillingUserSynchronizationFailed')) {
+      if (user.notifications && Utils.objectHasProperty(user.notifications, 'sendBillingUserSynchronizationFailed')) {
         this.notifications.controls.sendBillingUserSynchronizationFailed.setValue(user.notifications.sendBillingUserSynchronizationFailed);
       } else {
         this.notifications.controls.sendBillingUserSynchronizationFailed.setValue(false);
       }
-      if (user.notifications && user.notifications.hasOwnProperty('sendUserAccountInactivity')) {
+      if (user.notifications && Utils.objectHasProperty(user.notifications, 'sendUserAccountInactivity')) {
         this.notifications.controls.sendUserAccountInactivity.setValue(user.notifications.sendUserAccountInactivity);
       } else {
         this.notifications.controls.sendUserAccountInactivity.setValue(false);
       }
-      if (user.notifications && user.notifications.hasOwnProperty('sendSessionNotStarted')) {
+      if (user.notifications && Utils.objectHasProperty(user.notifications, 'sendSessionNotStarted')) {
         this.notifications.controls.sendSessionNotStarted.setValue(user.notifications.sendSessionNotStarted);
       } else {
         this.notifications.controls.sendSessionNotStarted.setValue(false);

--- a/src/app/shared/component/consumption-chart/consumption-chart-detail.component.ts
+++ b/src/app/shared/component/consumption-chart/consumption-chart-detail.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnChanges, OnInit, SimpleChanges, ViewChild } from '@
 import { ConsumptionChartComponent } from 'app/shared/component/consumption-chart/consumption-chart.component';
 import { Connector } from 'app/types/ChargingStation';
 import { Transaction } from 'app/types/Transaction';
+import { Utils } from '../../../utils/Utils';
 import { CellContentTemplateComponent } from '../../table/cell-content-template/cell-content-template.component';
 
 @Component({
@@ -16,7 +17,7 @@ export class ConsumptionChartDetailComponent extends CellContentTemplateComponen
 
   ngOnInit(): void {
     // Set the transaction id
-    if (this.row.hasOwnProperty('activeTransactionID')) {
+    if (Utils.objectHasProperty(this.row, 'activeTransactionID')) {
       // Connector
       this.transactionId = (this.row as Connector).activeTransactionID;
     } else {
@@ -27,7 +28,7 @@ export class ConsumptionChartDetailComponent extends CellContentTemplateComponen
 
   ngOnChanges(changes: SimpleChanges): void {
     // Set the transaction id
-    if (this.row.hasOwnProperty('activeTransactionID')) {
+    if (Utils.objectHasProperty(this.row, 'activeTransactionID')) {
       // Connector
       this.transactionId = (this.row as Connector).activeTransactionID;
     } else {

--- a/src/app/shared/component/consumption-chart/consumption-chart.component.ts
+++ b/src/app/shared/component/consumption-chart/consumption-chart.component.ts
@@ -156,7 +156,7 @@ export class ConsumptionChartComponent implements AfterViewInit {
         ...Utils.formatLineColor(this.consumptionColor),
         label: this.translateService.instant('transactions.graph.energy'),
       });
-      if (this.transaction.values.find((c) => c.hasOwnProperty('pricingSource')) !== undefined) {
+      if (this.transaction.values.find((c) => Utils.objectHasProperty(c, 'pricingSource')) !== undefined) {
         datasets.push({
           name: 'cumulatedAmount',
           type: 'line',

--- a/src/app/shared/dialogs/dialog-table-data.component.ts
+++ b/src/app/shared/dialogs/dialog-table-data.component.ts
@@ -2,6 +2,7 @@ import { Inject } from '@angular/core';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { KeyValue } from 'app/types/GlobalType';
 import { Data } from 'app/types/Table';
+import { Utils } from '../../utils/Utils';
 import { DialogTableDataSource } from './dialog-table-data-source';
 
 export abstract class DialogTableDataComponent<T extends Data> {
@@ -36,7 +37,7 @@ export abstract class DialogTableDataComponent<T extends Data> {
       this.dialogDataSource.setStaticFilters([]);
     }
     // Multiple Selection
-    if (data.hasOwnProperty('rowMultipleSelection')) {
+    if (Utils.objectHasProperty(data, 'rowMultipleSelection')) {
       this.dialogDataSource.setMultipleRowSelection(data.rowMultipleSelection);
     }
     // listen to keystroke

--- a/src/app/shared/dialogs/transactions/transaction-dialog.component.ts
+++ b/src/app/shared/dialogs/transactions/transaction-dialog.component.ts
@@ -167,7 +167,7 @@ export class TransactionDialogComponent implements OnInit, OnDestroy {
       }
       this.percentOfInactivity =
         ` (${this.appPercentPipe.transform(this.totalDurationSecs > 0 ? this.totalInactivitySecs / this.totalDurationSecs : 0, '1.0-0')})`;
-      if (transaction.hasOwnProperty('stateOfCharge')) {
+      if (Utils.objectHasProperty(transaction, 'stateOfCharge')) {
         if (this.stateOfCharge === 100) {
           this.stateOfChargeIcon = 'battery_full';
         } else if (this.stateOfCharge >= 90) {

--- a/src/app/shared/table/table-data-source.ts
+++ b/src/app/shared/table/table-data-source.ts
@@ -4,10 +4,11 @@ import { MatSort } from '@angular/material/sort';
 import { SpinnerService } from 'app/services/spinner.service';
 import { DataResult, Ordering, Paging } from 'app/types/DataResult';
 import { Data, DropdownItem, FilterType, TableActionDef, TableColumnDef, TableDef, TableFilterDef } from 'app/types/Table';
-import { Observable, of } from 'rxjs';
+import { of, Observable } from 'rxjs';
 import { first } from 'rxjs/operators';
 import ChangeNotification from '../../types/ChangeNotification';
 import { Constants } from '../../utils/Constants';
+import { Utils } from '../../utils/Utils';
 import { TableResetFiltersAction } from './actions/table-reset-filters-action';
 
 export abstract class TableDataSource<T extends Data> {
@@ -56,7 +57,7 @@ export abstract class TableDataSource<T extends Data> {
   }
 
   public hasRowDetailsHideShowField(): boolean {
-    return !!this.tableDef && !!this.tableDef.rowDetails && this.tableDef.rowDetails.hasOwnProperty('showDetailsField');
+    return !!this.tableDef && !!this.tableDef.rowDetails && Utils.objectHasProperty(this.tableDef.rowDetails, 'showDetailsField');
   }
 
   public isMultiSelectionEnabled(): boolean {
@@ -657,7 +658,7 @@ export abstract class TableDataSource<T extends Data> {
         // Check if the table has a specific field to hide/show details
         if (this.tableDef && this.tableDef.rowDetails && this.tableDef.rowDetails.showDetailsField) {
           // Check if it's still visible
-          if (freshRow.hasOwnProperty(this.tableDef.rowDetails.showDetailsField)) {
+          if (Utils.objectHasProperty(freshRow, this.tableDef.rowDetails.showDetailsField)) {
             // Set
             // @ts-ignore
             freshRow.isExpanded = freshRow[this.tableDef.rowDetails.showDetailsField];

--- a/src/app/utils/Utils.ts
+++ b/src/app/utils/Utils.ts
@@ -83,7 +83,7 @@ export class Utils {
     return value ? value.replace(/\n/g, '') : '';
   }
 
-  public static hasOwnProperty(object: object, key: string): boolean {
+  public static objectHasProperty(object: object, key: string): boolean {
     return Object.prototype.hasOwnProperty.call(object, key);
   }
 


### PR DESCRIPTION
I renamed the function to objectHasProperty because hasOwnProperty was still interpreted as an error by the Linter as a usage of built-in prototype on Utils instance. (as LucasBrazi06/ev-server#1176)