### PR TITLE
Removed clear button

### DIFF
--- a/src/app/pages/organization/site-areas/site-area/site-area.component.html
+++ b/src/app/pages/organization/site-areas/site-area/site-area.component.html
@@ -72,10 +72,6 @@
                   <mat-form-field *ngIf="isSmartChargingComponentActive">
                     <input matInput placeholder="{{'site_areas.maximum_energy' | translate}}"
                       type="text" [formControl]="maximumPower">
-                    <button mat-button matSuffix mat-icon-button aria-label="Reset"
-                      (click)="clearMaximumPower()" [hidden]="maximumPower.value === null || maximumPower.value === ''">
-                      <mat-icon>clear</mat-icon>
-                    </button>
                     <mat-error *ngIf="maximumPower.errors?.min">{{"general.error_min_value" | translate:{value: 1} }}</mat-error>
                     <mat-error *ngIf="maximumPower.errors?.pattern">{{"chargers.invalid_power_value" | translate}}</mat-error>
                     <mat-error *ngIf="maximumPower.errors?.required">{{"general.mandatory_field" | translate}}</mat-error>

--- a/src/app/pages/organization/site-areas/site-area/site-area.component.ts
+++ b/src/app/pages/organization/site-areas/site-area/site-area.component.ts
@@ -185,10 +185,6 @@ export class SiteAreaComponent implements OnInit {
     });
   }
 
-  public clearMaximumPower() {
-    this.maximumPower.setValue(null);
-    this.formGroup.markAsDirty();
-  }
 
   public loadSiteArea() {
     if (!this.currentSiteAreaID) {


### PR DESCRIPTION
As discussed in the meeting on Monday I got rid of the clear button in the MaxPower-input in the site area dialog, because there is no real added value from it.