### PR TITLE
Bug fix disabling manual config

### DIFF
--- a/src/app/pages/charging-stations/charging-station/parameters/charging-station-parameters.component.ts
+++ b/src/app/pages/charging-stations/charging-station/parameters/charging-station-parameters.component.ts
@@ -344,8 +344,11 @@ export class ChargingStationParametersComponent implements OnInit, OnChanges {
           this.manualConfiguration.setValue(true);
         } else {
           this.maximumPower.disable();
+          // Check initial charging station
+          if(!this.chargingStation.manualConfiguration) {
           // Reload initial charging station to restore e.g. maximum power, when it was changed by the adjustment methods
-          this.loadChargingStation();
+            this.loadChargingStation();
+          }
         }
       });
     }


### PR DESCRIPTION
Added a check of the manual configuration of the initial station. 
Without the check manual config cannot be disabled, once enabled and saved.