### PR TITLE
Charging Plans - check form group before refreshing

### DIFF
--- a/src/app/pages/charging-stations/charging-station-limitation/charging-plans/charging-plans.component.ts
+++ b/src/app/pages/charging-stations/charging-station-limitation/charging-plans/charging-plans.component.ts
@@ -180,7 +180,7 @@ export class ChargingPlansComponent implements OnInit, AfterViewInit, OnChanges 
   }
 
   public ngOnChanges() {
-    if (this.autoRefreshEnabled) {
+    if (this.autoRefreshEnabled && !this.formGroup.dirty) {
       this.refresh();
     }
   }


### PR DESCRIPTION
To be checked if the ngOnChanges is needed here. I do not see a reason for it. 
The change of a charging profile in the database is handled in the constructor.