### PR TITLE
billing - settings - consume new REST endpoints

### DIFF
--- a/src/app/pages/settings-integration/billing/settings-billing.component.ts
+++ b/src/app/pages/settings-integration/billing/settings-billing.component.ts
@@ -73,8 +73,10 @@ export class SettingsBillingComponent implements OnInit {
       return ;
     }
     const { immediateBillingAllowed, periodicBillingAllowed, taxID } = newSettings.stripe; // TODO - ?? newSettings.billing?
+    // TODO - isTransactionBillingActivated is not yet visible - Add means to the UI to activate it
+    const isTransactionBillingActivated = false;
     const billing: BillingSetting = {
-      immediateBillingAllowed, periodicBillingAllowed, taxID
+      isTransactionBillingActivated, immediateBillingAllowed, periodicBillingAllowed, taxID,
     };
     const { url, publicKey, secretKey } = newSettings.stripe;
     const stripe: StripeBillingSetting  = {

--- a/src/app/services/central-server.service.ts
+++ b/src/app/services/central-server.service.ts
@@ -27,7 +27,7 @@ import { OCPPResetType } from '../types/ocpp/OCPP';
 import { RefundReport } from '../types/Refund';
 import { RegistrationToken } from '../types/RegistrationToken';
 import { ServerAction, ServerRoute } from '../types/Server';
-import { SettingDB } from '../types/Setting';
+import { BillingSettings, SettingDB } from '../types/Setting';
 import { Site, SiteUser } from '../types/Site';
 import { SiteArea, SiteAreaConsumption } from '../types/SiteArea';
 import { StatisticData } from '../types/Statistic';
@@ -1524,17 +1524,43 @@ export class CentralServerService {
       );
   }
 
+  public getBillingSettings(): Observable<BillingSettings> {
+    // verify init
+    this.checkInit();
+    // Build the URL
+    const url = this.buildRestEndpointUrl(ServerRoute.REST_BILLING_SETTING);
+    // Execute the REST Service
+    return this.httpClient.get<BillingSettings>(url, {
+      headers: this.buildHttpHeaders()
+    }).pipe(
+      catchError(this.handleHttpError),
+    );
+  }
+
+  public updateBillingSettings(billingSettings: BillingSettings): Observable<ActionResponse> {
+    // Verify init
+    this.checkInit();
+    // Build the URL
+    const url = this.buildRestEndpointUrl(ServerRoute.REST_BILLING_SETTING);
+    // Execute
+    return this.httpClient.put<ActionResponse>(url, billingSettings, {
+      headers: this.buildHttpHeaders(),
+    }).pipe(
+      catchError(this.handleHttpError),
+    );
+  }
+
   public checkBillingConnection(): Observable<CheckBillingConnectionResponse> {
     // verify init
     this.checkInit();
+    // Build the URL
+    const url = this.buildRestEndpointUrl(ServerRoute.REST_BILLING_CHECK);
     // Execute the REST Service
-    return this.httpClient.get<CheckBillingConnectionResponse>(`${this.centralRestServerServiceSecuredURL}/${ServerAction.CHECK_BILLING_CONNECTION}`,
-      {
-        headers: this.buildHttpHeaders(),
-      })
-      .pipe(
-        catchError(this.handleHttpError),
-      );
+    return this.httpClient.post<CheckBillingConnectionResponse>(url, {}, {
+      headers: this.buildHttpHeaders()
+    }).pipe(
+      catchError(this.handleHttpError),
+    );
   }
 
   public synchronizeUsersForBilling(): Observable<ActionsResponse> {

--- a/src/app/services/component.service.ts
+++ b/src/app/services/component.service.ts
@@ -97,22 +97,8 @@ export class ComponentService {
     if (!settings.type) {
       settings.type = BillingSettingsType.STRIPE;
     }
-    // Build setting payload
-    const settingsToSave = {
-      id: settings.id,
-      identifier: TenantComponents.BILLING,
-      sensitiveData: [],
-      content: Utils.cloneObject(settings),
-    };
-    if (settings.type === BillingSettingsType.STRIPE) {
-      settingsToSave.sensitiveData = ['content.stripe.secretKey'];
-    }
-    // Delete IDS
-    delete settingsToSave.content.id;
-    delete settingsToSave.content.identifier;
-    delete settingsToSave.content.sensitiveData;
     // Save
-    return this.centralServerService.updateSetting(settingsToSave);
+    return this.centralServerService.updateBillingSettings(settings);
   }
 
   public saveRefundSettings(settings: RefundSettings): Observable<ActionResponse> {
@@ -267,28 +253,11 @@ export class ComponentService {
     return this.centralServerService.updateSetting(settingsToSave);
   }
 
+
   public getBillingSettings(): Observable<BillingSettings> {
     return new Observable((observer) => {
-      const billingSettings = {
-        identifier: TenantComponents.BILLING,
-      } as BillingSettings;
       // Get the Billing settings
-      this.centralServerService.getSetting(TenantComponents.BILLING).subscribe((settings) => {
-        if (settings) {
-          const config = settings.content;
-          // ID
-          billingSettings.id = settings.id;
-          billingSettings.sensitiveData = settings.sensitiveData;
-          // billing common properties
-          if (config.billing) {
-            billingSettings.billing = config.billing;
-          }
-          // Stripe
-          if (config.stripe) {
-            billingSettings.type = BillingSettingsType.STRIPE;
-            billingSettings.stripe = config.stripe;
-          }
-        }
+      this.centralServerService.getBillingSettings().subscribe((billingSettings) => {
         observer.next(billingSettings);
         observer.complete();
       }, (error) => {

--- a/src/app/types/Server.ts
+++ b/src/app/types/Server.ts
@@ -409,7 +409,6 @@ export enum ServerAction {
   BILLING_SYNCHRONIZE_USERS = 'BillingSynchronizeUsers',
   BILLING_SYNCHRONIZE_USER = 'BillingSynchronizeUser',
   BILLING_FORCE_SYNCHRONIZE_USER = 'BillingForceSynchronizeUser',
-  CHECK_BILLING_CONNECTION = 'CheckBillingConnection',
   BILLING_TAXES = 'BillingTaxes',
   BILLING_INVOICES = 'BillingUserInvoices',
   BILLING_USER_INVOICE = 'BillingUserInvoice',
@@ -505,4 +504,7 @@ export enum ServerRoute {
   REST_BILLING_PAYMENT_METHOD_SETUP = 'users/:userID/payment-methods/setup',
   REST_BILLING_PAYMENT_METHOD_ATTACH = 'users/:userID/payment-methods/:paymentMethodID/attach',
   REST_BILLING_PAYMENT_METHOD_DETACH = 'users/:userID/payment-methods/:paymentMethodID/detach',
+
+  REST_BILLING_SETTING = 'billing-setting', // GET and PUT
+  REST_BILLING_CHECK = 'billing/check'
 }

--- a/src/app/types/Setting.ts
+++ b/src/app/types/Setting.ts
@@ -196,7 +196,7 @@ export interface ConcurRefundSetting {
   reportName: string;
 }
 
-export interface BillingSettings extends Setting{
+export interface BillingSettings extends Setting {
   identifier: TenantComponents.BILLING;
   type: BillingSettingsType;
   billing: BillingSetting;
@@ -204,6 +204,7 @@ export interface BillingSettings extends Setting{
 }
 
 export interface BillingSetting {
+  isTransactionBillingActivated: boolean;
   immediateBillingAllowed: boolean;
   periodicBillingAllowed: boolean;
   taxID: string;


### PR DESCRIPTION
The getBillingSettings/setBillingSettings do not use the generic settings endpoints anymore.

The new routes are now used and the logic to convert the settings into the internal format (SettingDB) is now only on the backend-side. 