### PR TITLE
sap cp xsuaa integration (draft)

### DIFF
--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -1,7 +1,8 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { Utils } from 'utils/Utils';
 
-import AdvancedConfiguration from '../types/configuration/AdvancedConfiguration';
+import AdvancedConfiguration, { AuthServiceType } from '../types/configuration/AdvancedConfiguration';
 import AssetConfiguration from '../types/configuration/AssetConfiguration';
 import AuthorizationConfiguration from '../types/configuration/AuthorizationConfiguration';
 import CarConfiguration from '../types/configuration/CarConfiguration';
@@ -55,6 +56,9 @@ export class ConfigService {
   }
 
   public getAdvanced(): AdvancedConfiguration {
+    if (Utils.isUndefined(this.getConfig().Advanced.globalAuthenticationService)) {
+      this.getConfig().Advanced.globalAuthenticationService = AuthServiceType.BUILT_IN;
+    }
     return this.getConfig().Advanced;
   }
 

--- a/src/app/types/Server.ts
+++ b/src/app/types/Server.ts
@@ -437,6 +437,7 @@ export enum ServerAction {
 // RESTful API
 export enum ServerRoute {
   REST_SIGNIN = 'signin',
+  REST_SIGNINXSUAA = 'signinxsuaa',
   REST_SIGNON = 'signon',
   REST_SIGNOUT = 'signout',
   REST_PASSWORD_RESET = 'password/reset',

--- a/src/app/types/configuration/AdvancedConfiguration.ts
+++ b/src/app/types/configuration/AdvancedConfiguration.ts
@@ -1,4 +1,10 @@
 export default interface AdvancedConfiguration {
   debounceTimeNotifMillis: number;
   debounceTimeSearchMillis: number;
+  globalAuthenticationService?: string; /* built-in | xsuaa*/
+}
+
+export enum AuthServiceType {
+  XSUAA = 'xsuaa',
+  BUILT_IN = 'built-in'
 }

--- a/src/app/types/configuration/CentralSystemServerConfiguration.ts
+++ b/src/app/types/configuration/CentralSystemServerConfiguration.ts
@@ -6,4 +6,5 @@ export default interface CentralSystemServerConfiguration {
   pollIntervalSecs?: number;
   socketIOEnabled?: boolean;
   logoutOnConnectionError?: boolean;
+  subpath: string;
 }


### PR DESCRIPTION
Notes:
The following solution will use the AppRouter as the single entry point for all emobility modules (dashboard, rest server, etc.).
All calls from the web app (dashboard) to the rest server will pass via AppRouter.
This reason of this approach is because we haven't succeeded to use 2 passports in the AuthService.ts class. If we find a way to do that, we can discuss about using direct calls to the rest server (but what about cross origin then?).

(see Visio diagram in archi folder in ev-server PR)

the principle of xsuaa is to hide the jwt token from the browser application. The web application will only receive a JSESSIONID which the browser will send to the approuter and the approuter will inject the Authorization:
when the web app is launched, it will check if it has a emobility token in its local storage. If not, it will go to the "login" web page and make an automatic call to "/loginxsuaa" server route. The server will send back the emobility token.
for the subsequent calls, the web app will send the emobility token in the special header, and the server will read it and use it.
must discuss about the end-user onboarding process. 
For the moment, during login xsuaa, if the user is not found in the database, he will get a error (user not found).

New parameters:
 - globalAuthenticationService: to AdvancedConfiguration to distinguish the authentication type: xsuaa / built-in. If the parameter doesn't exist, the "built-in" will be used.
 - subpath in CentralSystemServer config in order to be able to specify the correct path in the approuter;  example: "ev-approuter.cfapps.sap.hana.ondemand.com/backend"

route-guard.ts
will contain a different login approach depending on globalAuthenticationService parameter. For xsuaa, the web app will pass through the login page but will not display the classic user/password text boxes, but will make a login call to the rest server (/loginxusaa) and go to the /charging-stations page