### PR TITLE
Fix Issue #1694. Search field missing reset.

### DIFF
--- a/src/app/shared/table/table.component.html
+++ b/src/app/shared/table/table.component.html
@@ -140,6 +140,9 @@
         <div *ngIf="dataSource.isSearchEnabled" class="col search-form">
           <mat-form-field>
             <input appAutofocus autocomplete="off" #searchInput [placeholder]="searchPlaceholder | translate" matInput>
+            <button mat-icon-button matSuffix (click)="resetSearchFilter()" aria-label="Add">
+              <mat-icon>clear</mat-icon>
+            </button>
           </mat-form-field>
         </div>
       </div>

--- a/src/app/shared/table/table.component.html
+++ b/src/app/shared/table/table.component.html
@@ -110,7 +110,7 @@
             <input (click)="showDialogTableFilter(filterDef)" [placeholder]="filterDef.name | translate"
               [value]="(filterDef.currentValue ? filterDef.currentValue[0].value : filterDef.defaultValue) | translate"
               class="form-field-popup" matInput readonly=true type="text" />
-            <button mat-icon-button matSuffix (click)="resetDialogTableFilter(filterDef)" aria-label="Add">
+            <button mat-icon-button matSuffix (click)="resetDialogTableFilter(filterDef)" aria-label="Clear">
               <mat-icon>clear</mat-icon>
             </button>
           </mat-form-field>
@@ -118,7 +118,7 @@
           <mat-form-field *ngIf="filterDef.type === FilterType.DIALOG_TABLE && filterDef.multiple">
             <input (click)="showDialogTableFilter(filterDef)" [placeholder]="filterDef.name | translate"
               [value]="filterDef.label" class="form-field-popup" matInput readonly=true type="text" />
-            <button mat-icon-button matSuffix (click)="resetDialogTableFilter(filterDef)" aria-label="Add">
+            <button mat-icon-button matSuffix (click)="resetDialogTableFilter(filterDef)" aria-label="Clear">
               <mat-icon>clear</mat-icon>
             </button>
           </mat-form-field>
@@ -140,7 +140,7 @@
         <div *ngIf="dataSource.isSearchEnabled" class="col search-form">
           <mat-form-field>
             <input appAutofocus autocomplete="off" #searchInput [placeholder]="searchPlaceholder | translate" matInput>
-            <button mat-icon-button matSuffix (click)="resetSearchFilter()" aria-label="Add">
+            <button mat-icon-button matSuffix (click)="resetSearchFilter()" aria-label="Clear">
               <mat-icon>clear</mat-icon>
             </button>
           </mat-form-field>

--- a/src/app/shared/table/table.component.ts
+++ b/src/app/shared/table/table.component.ts
@@ -267,6 +267,12 @@ export class TableComponent implements OnInit, AfterViewInit, OnDestroy {
     this.refresh();
   }
 
+  public resetSearchFilter(){
+    this.searchInput.nativeElement.value = '';
+    this.dataSource.setSearchValue('');
+    this.refresh();
+  }
+
   public actionTriggered(actionDef: TableActionDef, event?: MouseEvent | MatSlideToggleChange) {
     // Slide
     if (event && event instanceof MatSlideToggleChange && actionDef.type === 'slide') {


### PR DESCRIPTION
Search filter is a common filter across all pages. As a result the changes were done to the table component where this filter is implemented. 

The HTML changes are adding a reset cross like the dialog filter available for inputs prior to the search filter. Clicking this reset cross calls the 'resetSearchFilter()' which sets empties the element value as well as the sets the search value in datasource to empty value. The table component is then refreshed. 