### PR TITLE
Max character limit set while entering strings.

### DIFF
--- a/src/app/pages/assets/asset/asset.component.html
+++ b/src/app/pages/assets/asset/asset.component.html
@@ -47,6 +47,9 @@
                   <mat-error *ngIf="name.errors?.required">
                     {{"general.mandatory_field" | translate}}
                   </mat-error>
+                  <mat-error *ngIf="name.errors?.maxlength">
+                    <div [translateParams]="{length: name.errors?.maxlength?.requiredLength}" [translate]="'general.error_max_length'"></div>
+                  </mat-error>
                 </mat-form-field>
               </div>
               <div class="form-group">

--- a/src/app/pages/assets/asset/asset.component.ts
+++ b/src/app/pages/assets/asset/asset.component.ts
@@ -94,6 +94,7 @@ export class AssetComponent implements OnInit {
       name: new FormControl('',
         Validators.compose([
           Validators.required,
+          Validators.maxLength(255),
         ])),
       siteArea: new FormControl('',
         Validators.compose([

--- a/src/app/pages/organization/site-areas/site-area/site-area.component.html
+++ b/src/app/pages/organization/site-areas/site-area/site-area.component.html
@@ -50,6 +50,9 @@
                       <mat-error *ngIf="name.errors?.required">
                         {{"general.mandatory_field" | translate}}
                       </mat-error>
+                      <mat-error *ngIf="name.errors?.maxlength">
+                        <div [translateParams]="{length: name.errors?.maxlength?.requiredLength}" [translate]="'general.error_max_length'"></div>
+                      </mat-error>
                     </mat-form-field>
                     <mat-form-field *ngIf="formGroup.enabled">
                       <input matInput type="text" readonly=true placeholder="{{'sites.site' | translate}}"

--- a/src/app/pages/organization/site-areas/site-area/site-area.component.ts
+++ b/src/app/pages/organization/site-areas/site-area/site-area.component.ts
@@ -94,6 +94,7 @@ export class SiteAreaComponent implements OnInit {
       name: new FormControl('',
         Validators.compose([
           Validators.required,
+          Validators.maxLength(255),
         ])
       ),
       site: new FormControl('',

--- a/src/app/pages/organization/sites/site/site.component.html
+++ b/src/app/pages/organization/sites/site/site.component.html
@@ -49,6 +49,9 @@
                       <mat-error *ngIf="name.errors?.required">
                         {{"general.mandatory_field" | translate}}
                       </mat-error>
+                      <mat-error *ngIf="name.errors?.maxlength">
+                        <div [translateParams]="{length: name.errors?.maxlength?.requiredLength}" [translate]="'general.error_max_length'"></div>
+                      </mat-error>
                     </mat-form-field>
                   </div>
                   <div class="form-group">

--- a/src/app/pages/organization/sites/site/site.component.ts
+++ b/src/app/pages/organization/sites/site/site.component.ts
@@ -62,6 +62,7 @@ export class SiteComponent implements OnInit {
       name: new FormControl('',
         Validators.compose([
           Validators.required,
+          Validators.maxLength(255),
         ])),
       company: new FormControl('',
         Validators.compose([

--- a/src/app/pages/users/user/user.component.html
+++ b/src/app/pages/users/user/user.component.html
@@ -47,6 +47,9 @@
                     <mat-error *ngIf="name.errors?.required">
                       {{"general.mandatory_field" | translate}}
                     </mat-error>
+                    <mat-error *ngIf="name.errors?.maxlength">
+                      <div [translateParams]="{length: name.errors?.maxlength?.requiredLength}" [translate]="'general.error_max_length'"></div>
+                    </mat-error>
                   </mat-form-field>
                 </div>
                 <div class="form-group">
@@ -54,7 +57,10 @@
                     <input [formControl]="firstName" matInput
                       placeholder="{{'users.first_name' | translate}}" required type="text">
                     <mat-error *ngIf="firstName.errors?.required">
-                      {{"general.mandatory_field" | translate}}
+                      {{ "general.mandatory_field" | translate }}
+                    </mat-error>
+                    <mat-error *ngIf="name.errors?.maxlength">
+                      <div [translateParams]="{length: name.errors?.maxlength?.requiredLength}" [translate]="'general.error_max_length'"></div>
                     </mat-error>
                   </mat-form-field>
                 </div>

--- a/src/app/pages/users/user/user.component.ts
+++ b/src/app/pages/users/user/user.component.ts
@@ -171,10 +171,12 @@ export class UserComponent extends AbstractTabComponent implements OnInit {
       name: new FormControl('',
         Validators.compose([
           Validators.required,
+          Validators.maxLength(255),
         ])),
       firstName: new FormControl('',
         Validators.compose([
           Validators.required,
+          Validators.maxLength(255),
         ])),
       notificationsActive: new FormControl(true),
       notifications: new FormGroup({


### PR DESCRIPTION
Input fields were missing validation on max size of string input for certain fields. Fixed by adding "Validator.maxLength(255)" and attaching the error output in the template file.