### PR TITLE
Add owner filter in assets

### DIFF
--- a/src/app/pages/assets/in-error/assets-in-error-table-data-source.ts
+++ b/src/app/pages/assets/in-error/assets-in-error-table-data-source.ts
@@ -17,6 +17,7 @@ import { TableAutoRefreshAction } from '../../../shared/table/actions/table-auto
 import { TableMoreAction } from '../../../shared/table/actions/table-more-action';
 import { TableRefreshAction } from '../../../shared/table/actions/table-refresh-action';
 import { ErrorTypeTableFilter } from '../../../shared/table/filters/error-type-table-filter';
+import { IssuerFilter } from '../../../shared/table/filters/issuer-filter';
 import { SiteAreaTableFilter } from '../../../shared/table/filters/site-area-table-filter';
 import { TableDataSource } from '../../../shared/table/table-data-source';
 import { AssetButtonAction } from '../../../types/Asset';
@@ -150,6 +151,7 @@ export class AssetsInErrorTableDataSource extends TableDataSource<AssetInError> 
     // Sort
     errorTypes.sort(Utils.sortArrayOfKeyValue);
     return [
+      new IssuerFilter().getFilterDef(),
       new SiteAreaTableFilter().getFilterDef(),
       new ErrorTypeTableFilter(errorTypes).getFilterDef(),
     ];

--- a/src/app/pages/assets/list/assets-list-table-data-source.ts
+++ b/src/app/pages/assets/list/assets-list-table-data-source.ts
@@ -19,6 +19,7 @@ import { TableAutoRefreshAction } from '../../../shared/table/actions/table-auto
 import { TableMoreAction } from '../../../shared/table/actions/table-more-action';
 import { TableOpenInMapsAction } from '../../../shared/table/actions/table-open-in-maps-action';
 import { TableRefreshAction } from '../../../shared/table/actions/table-refresh-action';
+import { IssuerFilter } from '../../../shared/table/filters/issuer-filter';
 import { TableDataSource } from '../../../shared/table/table-data-source';
 import { Asset, AssetButtonAction, AssetType } from '../../../types/Asset';
 import ChangeNotification from '../../../types/ChangeNotification';
@@ -182,7 +183,7 @@ export class AssetsListTableDataSource extends TableDataSource<Asset> {
     const openInMaps = new TableOpenInMapsAction().getActionDef();
     // Check if GPS is available
     openInMaps.disabled = !Utils.containsGPSCoordinates(asset.coordinates);
-    if (this.isAdmin) {
+    if (this.isAdmin && asset.issuer) {
       actions.push(this.editAction);
       actions.push(new TableMoreAction([
         openInMaps,
@@ -254,6 +255,8 @@ export class AssetsListTableDataSource extends TableDataSource<Asset> {
   }
 
   public buildTableFiltersDef(): TableFilterDef[] {
-    return [];
+    return [
+      new IssuerFilter().getFilterDef(),
+    ];
   }
 }

--- a/src/app/types/Asset.ts
+++ b/src/app/types/Asset.ts
@@ -24,6 +24,7 @@ export interface Asset extends TableData, CreatedUpdatedProps, AbstractCurrentCo
   lastChangedOn: Date;
   connected: boolean;
   excludeFromSmartCharging?: boolean;
+  issuer: boolean;
 }
 
 export interface AssetConsumption {


### PR DESCRIPTION
Adding owner filter in Assets and Assets in error page. This required adding an IssuerFilter in the dashboard so as to make the filter visible on the UI.