### PR TITLE
Changes made to keep selected filter values when search value changes.

### DIFF
--- a/src/app/shared/dialogs/logs/log-actions-dialog-table-data-source.ts
+++ b/src/app/shared/dialogs/logs/log-actions-dialog-table-data-source.ts
@@ -34,9 +34,11 @@ export class LOG_ACTIONSDialogTableDataSource extends DialogTableDataSource<LogA
         LOG_ACTIONS.reverse();
         this.reversed = false;
       }
+      const selectedRowsActions = this.getSelectedRows().map(value => value.action.toString().toLowerCase());
       // const sortedActions = this.getSort().direction === 'desc' && !reversed ? LOG_ACTIONS.reverse() : LOG_ACTIONS;
       for (const [key, value] of Object.entries(LOG_ACTIONS)) {
-        if (value.value.toLowerCase().includes(searchValue.toLowerCase())) {
+        const actionValue = value.value.toLowerCase();
+        if (actionValue.includes(searchValue.toLowerCase()) || selectedRowsActions.includes(actionValue)) {
           actions.push({
             action: value.value as ServerAction,
             key: value.key,


### PR DESCRIPTION
Selected rows were not included in the actions list when search was used. Adding a filter to include selected rows prevents them from being deleted. 