### PR TITLE
billing - settings - clear test data (minimal)

### DIFF
--- a/src/app/pages/settings-integration/billing/settings-billing.component.html
+++ b/src/app/pages/settings-integration/billing/settings-billing.component.html
@@ -28,6 +28,10 @@
       [disabled]="!formGroup.valid || formGroup.dirty || !billingSettings?.billing?.taxID || billingSettings?.billing?.isTransactionBillingActivated">
       <mat-icon>toggle_off</mat-icon><span>{{'settings.billing.transaction_billing_activation' | translate}}</span>
     </button>
+    <button *ngIf="isClearTestDataVisible" mat-raised-button color="warn" (click)="clearTestData()"
+      [disabled]="!formGroup.valid || formGroup.dirty">
+      <mat-icon>clear</mat-icon><span>{{'settings.billing.billing_clear_test_data' | translate}}</span>
+    </button>
     <!-- <button mat-raised-button color="primary" (click)="synchronizeInvoices()"
             [disabled]="!formGroup.valid || formGroup.dirty">
       <mat-icon>sync</mat-icon><span>{{'settings.billing.invoice.synchronize_invoices' | translate}}</span>

--- a/src/app/pages/settings-integration/billing/settings-billing.component.ts
+++ b/src/app/pages/settings-integration/billing/settings-billing.component.ts
@@ -27,6 +27,7 @@ export class SettingsBillingComponent implements OnInit {
   public formGroup!: FormGroup;
   public billingSettings!: BillingSettings;
   public transactionBillingActivated: boolean;
+  public isClearTestDataVisible = false;
 
   public constructor(
     private centralServerService: CentralServerService,
@@ -55,6 +56,8 @@ export class SettingsBillingComponent implements OnInit {
       this.spinnerService.hide();
       // Keep
       this.billingSettings = settings;
+      // Enable additional actions based on the account nature
+      this.checkConnectionContext(settings);
       // Init form
       this.formGroup.markAsPristine();
     }, (error) => {
@@ -165,5 +168,46 @@ export class SettingsBillingComponent implements OnInit {
         this.save(this.billingSettings);
       }
     });
+  }
+
+  private clearTestData() {
+    this.dialogService.createAndShowYesNoDialog(
+      this.translateService.instant('settings.billing.billing_clear_test_data_title'),
+      this.translateService.instant('settings.billing.billing_clear_test_data_confirm'),
+    ).subscribe((response) => {
+      if (response === ButtonType.YES) {
+        this.triggerTestDataCleanup();
+      }
+    });
+  }
+
+  private triggerTestDataCleanup() {
+    // Clear Test Data
+    this.spinnerService.show();
+    this.centralServerService.clearBillingTestData().subscribe((response) => {
+      this.spinnerService.hide();
+      if (response.succeeded) {
+        this.messageService.showSuccessMessage('settings.billing.billing_clear_test_data_success');
+        this.refresh();
+      } else {
+        Utils.handleError(JSON.stringify(response),
+          this.messageService, 'settings.billing.billing_clear_test_data_error');
+      }
+    }, (error) => {
+      this.spinnerService.hide();
+      Utils.handleHttpError(error, this.router, this.messageService, this.centralServerService, 'settings.billing.billing_clear_test_data_error');
+    });
+  }
+
+  private checkConnectionContext(settings: BillingSettings): void {
+    let isClearTestDataVisible = false;
+    if ( this.billingSettings?.billing?.isTransactionBillingActivated ) {
+      // TODO - Get the information via a dedicated endpoint it
+      if ( this.billingSettings?.type === 'stripe' && this.billingSettings?.stripe?.publicKey?.startsWith('pk_test_') ) {
+        isClearTestDataVisible = true;
+      }
+    }
+    // Show the "Clear Test Data" button
+    this.isClearTestDataVisible = isClearTestDataVisible;
   }
 }

--- a/src/app/pages/settings-integration/billing/settings-billing.component.ts
+++ b/src/app/pages/settings-integration/billing/settings-billing.component.ts
@@ -202,7 +202,7 @@ export class SettingsBillingComponent implements OnInit {
   private checkConnectionContext(settings: BillingSettings): void {
     let isClearTestDataVisible = false;
     if ( this.billingSettings?.billing?.isTransactionBillingActivated ) {
-      // TODO - Get the information via a dedicated endpoint it
+      // TODO - Get the information via a dedicated endpoint!
       if ( this.billingSettings?.type === 'stripe' && this.billingSettings?.stripe?.publicKey?.startsWith('pk_test_') ) {
         isClearTestDataVisible = true;
       }

--- a/src/app/pages/settings-integration/billing/stripe/settings-stripe.component.ts
+++ b/src/app/pages/settings-integration/billing/stripe/settings-stripe.component.ts
@@ -112,9 +112,11 @@ export class SettingsStripeComponent implements OnInit, OnChanges {
   }
 
   private updateFormData() {
-    if (this.billingSettings?.billing?.isTransactionBillingActivated) {
-      this.transactionBillingActivated = true;
+    this.transactionBillingActivated = this.billingSettings?.billing?.isTransactionBillingActivated
+    if (this.transactionBillingActivated) {
       this.formGroup.get('stripe')?.disable();
+    } else {
+      this.formGroup.get('stripe')?.enable();
     }
     if (!Utils.isEmptyObject(this.billingSettings?.stripe) && !Utils.isEmptyObject(this.formGroup.value)) {
       const stripeSetting = this.billingSettings.stripe;

--- a/src/app/services/central-server.service.ts
+++ b/src/app/services/central-server.service.ts
@@ -1568,6 +1568,19 @@ export class CentralServerService {
     );
   }
 
+  public clearBillingTestData(): Observable<BillingOperationResult> {
+    // Verify init
+    this.checkInit();
+    // Build the URL
+    const url = this.buildRestEndpointUrl(ServerRoute.REST_BILLING_CLEAR_TEST_DATA);
+    // Execute
+    return this.httpClient.post<BillingOperationResult>(url, {}, {
+      headers: this.buildHttpHeaders(),
+    }).pipe(
+      catchError(this.handleHttpError),
+    );
+  }
+
   public checkBillingConnection(): Observable<CheckBillingConnectionResponse> {
     // verify init
     this.checkInit();

--- a/src/assets/i18n/de.json
+++ b/src/assets/i18n/de.json
@@ -1539,6 +1539,11 @@
       "transaction_billing_activation_confirm": "Do you really want to activate the billing of charging sessions? <br><br> <strong> WARNING ! </strong> Once activated, you will NOT be able to deactivate it !",
       "transaction_billing_activation_success": "Billing of charging sessions has been successfully activated",
       "transaction_billing_activation_error": "Billing of charging sessions cannot be activated",
+      "billing_clear_test_data": "Delete Test Data",
+      "billing_clear_test_data_title": "Test Data Deletion",
+      "billing_clear_test_data_confirm": "Do you really want to delete all billing test data?",
+      "billing_clear_test_data_success": "The test data has been deleted",
+      "billing_clear_test_data_error": "Operation failed. The test data deletion has been aborted",
       "user": {
         "synchronize_users": "Abrechnungssynchronisierung",
         "synchronize_user": "Abrechnungssynchronisierung",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1539,6 +1539,11 @@
       "transaction_billing_activation_confirm": "Do you really want to activate the billing of charging sessions? <br><br> <strong> WARNING ! </strong> Once activated, you will NOT be able to deactivate it !",
       "transaction_billing_activation_success": "Billing of charging sessions has been successfully activated",
       "transaction_billing_activation_error": "Billing of charging sessions cannot be activated",
+      "billing_clear_test_data": "Delete Test Data",
+      "billing_clear_test_data_title": "Test Data Deletion",
+      "billing_clear_test_data_confirm": "Do you really want to delete all billing test data?",
+      "billing_clear_test_data_success": "The test data has been deleted",
+      "billing_clear_test_data_error": "Operation failed. The test data deletion has been aborted",
       "user": {
         "synchronize_users": "Synchronize Billing Users",
         "synchronize_user": "Synchronize Billing User",

--- a/src/assets/i18n/es.json
+++ b/src/assets/i18n/es.json
@@ -1539,6 +1539,11 @@
       "transaction_billing_activation_confirm": "Do you really want to activate the billing of charging sessions? <br><br> <strong> WARNING ! </strong> Once activated, you will NOT be able to deactivate it !",
       "transaction_billing_activation_success": "Billing of charging sessions has been successfully activated",
       "transaction_billing_activation_error": "Billing of charging sessions cannot be activated",
+      "billing_clear_test_data": "Delete Test Data",
+      "billing_clear_test_data_title": "Test Data Deletion",
+      "billing_clear_test_data_confirm": "Do you really want to delete all billing test data?",
+      "billing_clear_test_data_success": "The test data has been deleted",
+      "billing_clear_test_data_error": "Operation failed. The test data deletion has been aborted",
       "user": {
         "synchronize_users": "Sincronización del usuario (Facturación)",
         "synchronize_user": "Sincronización del usuario (Facturación)",

--- a/src/assets/i18n/fr.json
+++ b/src/assets/i18n/fr.json
@@ -1539,6 +1539,11 @@
       "transaction_billing_activation_confirm": "Voulez-vous vraiment activer la facturation des sessions de recharge ?<br><br> <strong> Attention ! </strong> Une fois activée, vous ne serez plus en mesure de la désactiver",
       "transaction_billing_activation_success": "La facturation des sessions de recharge a été activée avec succès",
       "transaction_billing_activation_error": "La facturation des sessions de recharge n'a pas pu être activée",
+      "billing_clear_test_data": "Supprimer les données de test",
+      "billing_clear_test_data_title": "Suppression des données de test",
+      "billing_clear_test_data_confirm": "Souhaitez-vous vraiment supprimer les données de test?",
+      "billing_clear_test_data_success": "Les données de test ont été supprimées",
+      "billing_clear_test_data_error": "L'opération a échoué. La suppression des données a été interrompue",
       "user": {
         "synchronize_users": "Synchro Utilisateurs (Facturation)",
         "synchronize_user": "Synchro Utilisateur (Facturation)",

--- a/src/assets/i18n/it.json
+++ b/src/assets/i18n/it.json
@@ -1539,6 +1539,11 @@
       "transaction_billing_activation_confirm": "Do you really want to activate the billing of charging sessions? <br><br> <strong> WARNING ! </strong> Once activated, you will NOT be able to deactivate it !",
       "transaction_billing_activation_success": "Billing of charging sessions has been successfully activated",
       "transaction_billing_activation_error": "Billing of charging sessions cannot be activated",
+      "billing_clear_test_data": "Delete Test Data",
+      "billing_clear_test_data_title": "Test Data Deletion",
+      "billing_clear_test_data_confirm": "Do you really want to delete all billing test data?",
+      "billing_clear_test_data_success": "The test data has been deleted",
+      "billing_clear_test_data_error": "Operation failed. The test data deletion has been aborted",
       "user": {
         "synchronize_users": "Sincronizza Utenti Fatturazione",
         "synchronize_user": "Sincronizza Utente Fatturazione",

--- a/src/assets/i18n/pt.json
+++ b/src/assets/i18n/pt.json
@@ -1539,6 +1539,11 @@
       "transaction_billing_activation_confirm": "Do you really want to activate the billing of charging sessions? <br><br> <strong> WARNING ! </strong> Once activated, you will NOT be able to deactivate it !",
       "transaction_billing_activation_success": "Billing of charging sessions has been successfully activated",
       "transaction_billing_activation_error": "Billing of charging sessions cannot be activated",
+      "billing_clear_test_data": "Delete Test Data",
+      "billing_clear_test_data_title": "Test Data Deletion",
+      "billing_clear_test_data_confirm": "Do you really want to delete all billing test data?",
+      "billing_clear_test_data_success": "The test data has been deleted",
+      "billing_clear_test_data_error": "Operation failed. The test data deletion has been aborted",
       "user": {
         "synchronize_users": "Sincronizar utilizadores de cobrança",
         "synchronize_user": "Sincronizar utilizador de cobrança",


### PR DESCRIPTION
"Delete Test Data" button added to the billling settings
Button is only shown whan billing is activated and stripe account is a test account.

Clicking this button has the following impact:
- test invoices are deleted
- transactions refering to test invoices are updated (removing the reference)
- users having a customerID are updated. customerID is therefore removed.
- billing settings are reinitialized to the initial state (no settings)

TODO: there is no endpoint so far to check the account type. As a workaround, we rely on the STRIPE publishable key syntax! This must be changed asap! 
