### PR TITLE
Fix Statitc filter dialog componenent

### DIFF
--- a/src/app/shared/dialogs/dialog-table-data.component.ts
+++ b/src/app/shared/dialogs/dialog-table-data.component.ts
@@ -31,7 +31,7 @@ export abstract class DialogTableDataComponent<T extends TableData> {
     // Set static filter
     if (data.staticFilter) {
       this.dialogDataSource.setStaticFilters([
-        ...this.dialogDataSource.getStaticFilters(),
+        this.dialogDataSource.getStaticFilters(),
         data.staticFilter,
       ]);
     }

--- a/src/app/shared/table/table-data-source.ts
+++ b/src/app/shared/table/table-data-source.ts
@@ -370,6 +370,8 @@ export abstract class TableDataSource<T extends TableData> {
                     filterDef.dialogComponentData.staticFilter[dependentFilter.httpId] =
                       dependentFilter.currentValue[0].key;
                   }
+                } else {
+                  delete filterDef.dialogComponentData.staticFilter[dependentFilter.httpId];
                 }
               }
             }


### PR DESCRIPTION
@LucasBrazi06 It seems to be not possible to prevent building URLs with null values since Angular's Http client is building the url. 

Here's another approche. 