### PR TITLE
fix: parse injected translated html

### DIFF
--- a/src/app/pages/settings-integration/analytics/settings-analytics.component.html
+++ b/src/app/pages/settings-integration/analytics/settings-analytics.component.html
@@ -6,7 +6,7 @@
     <h3 class="card-title">{{'settings.information' | translate}}</h3>
   </div>
   <div class="card-body">
-    <span>{{'settings.analytics.description' | translate}}</span>
+    <span [innerHtml]="'settings.analytics.description' | translate"></span>
     <a href="https://www.sapanalytics.cloud/solutions/" target="new"><u>SAP Analytics Cloud</u></a><br><br>
     {{'settings.activation_contact_msg' | translate}}
   </div>

--- a/src/app/pages/settings-integration/ocpi/settings-ocpi.component.html
+++ b/src/app/pages/settings-integration/ocpi/settings-ocpi.component.html
@@ -6,7 +6,7 @@
     <h3 class="card-title">{{'settings.information' | translate}}</h3>
   </div>
   <div class="card-body">
-    <div>{{'settings.ocpi.description' | translate}}</div><br>
+    <div [innerHtml]="'settings.ocpi.description' | translate"></div><br>
     {{'settings.activation_contact_msg' | translate}}
   </div>
 </div>

--- a/src/app/pages/settings-integration/oicp/settings-oicp.component.html
+++ b/src/app/pages/settings-integration/oicp/settings-oicp.component.html
@@ -6,7 +6,7 @@
     <h3 class="card-title">{{'settings.information' | translate}}</h3>
   </div>
   <div class="card-body">
-    <div>{{'settings.oicp.description' | translate}}</div><br>
+    <div [innerHtml]="'settings.oicp.description' | translate"></div><br>
     {{'settings.activation_contact_msg' | translate}}
   </div>
 </div>

--- a/src/app/pages/settings-integration/pricing/settings-pricing.component.html
+++ b/src/app/pages/settings-integration/pricing/settings-pricing.component.html
@@ -6,7 +6,7 @@
     <h3 class="card-title">{{'settings.information' | translate}}</h3>
   </div>
   <div class="card-body">
-    <span>{{'settings.pricing.full_description' | translate}}</span>
+    <span [innerHtml]="'settings.pricing.full_description' | translate"></span>
     <a href="https://help.sap.com/viewer/product/SAP_CONVERGENT_CHARGING/4.0/en-US" target="new"><u>SAP Convergent Charging</u></a><br><br>
     {{'settings.activation_contact_msg' | translate}}
   </div>

--- a/src/app/pages/settings-integration/refund/settings-refund.component.html
+++ b/src/app/pages/settings-integration/refund/settings-refund.component.html
@@ -6,7 +6,7 @@
     <h3 class="card-title">{{'settings.information' | translate}}</h3>
   </div>
   <div class="card-body">
-    <span>{{'settings.refund.description' | translate}}</span>
+    <span [innerHtml]="'settings.refund.description' | translate"></span>
     <a href='https://www.concur.com/' target='_blank'><u>SAP Concur</u></a><br><br>
     {{'settings.activation_contact_msg' | translate}}
   </div>

--- a/src/app/pages/tenants/tenant/tenant.component.html
+++ b/src/app/pages/tenants/tenant/tenant.component.html
@@ -116,7 +116,7 @@
                           </mat-slide-toggle>
                           <div class="d-flex flex-column me-auto ms-3 justify-content-around align-items-start w-100">
                             <div><strong><b>{{"ocpi.title" | translate}}</b></strong></div>
-                            <div>{{"ocpi.description" | translate}}</div>
+                            <div [innerHtml]="'ocpi.description' | translate"></div>
                           </div>
                         </div>
                         <div class="d-flex align-items-center component-item">
@@ -125,7 +125,7 @@
                           </mat-slide-toggle>
                           <div class="d-flex flex-column me-auto ms-3 justify-content-around align-items-start w-100">
                             <div><strong><b>{{"oicp.title" | translate}}</b></strong></div>
-                            <div>{{"oicp.description" | translate}}</div>
+                            <div [innerHtml]="'oicp.description' | translate"></div>
                           </div>
                         </div>
                         <div class="d-flex align-items-center component-item">
@@ -135,7 +135,7 @@
                           </mat-slide-toggle>
                           <div class="d-flex flex-column me-auto ms-3 justify-content-around align-items-start w-100">
                             <div><strong><b>{{"refund.title" | translate}}</b></strong></div>
-                            <div>{{"refund.description" | translate}}</div>
+                            <div [innerHtml]="'refund.description' | translate"></div>
                           </div>
                           <mat-form-field *ngIf="components['controls'].refund['controls'].active.value" class="flex-shrink-1 mx-5">
                             <mat-select [formControl]="components['controls'].refund['controls'].type"
@@ -233,7 +233,7 @@
                           </mat-slide-toggle>
                           <div class="d-flex flex-column me-auto ms-3 justify-content-around align-items-start w-100">
                             <div><strong><b>{{"analytics.title" | translate}}</b></strong></div>
-                            <div>{{"analytics.description" | translate}}</div>
+                            <div [innerHtml]="'analytics.description' | translate"></div>
                           </div>
                           <mat-form-field *ngIf="components['controls'].analytics['controls'].active.value" class="flex-shrink-1 mx-5">
                             <mat-select [formControl]="components['controls'].analytics['controls'].type"


### PR DESCRIPTION
This PR fixes the issue where html formatting is not being parsed after translation inline in the template.