### PR TITLE
BugFix  date range filter not updated to latest value with refresh

### DIFF
--- a/src/app/shared/table/table.component.html
+++ b/src/app/shared/table/table.component.html
@@ -66,7 +66,7 @@
             </ng-container>
             <!-- Refresh -->
             <button mat-raised-button *ngIf="actionRightDef.id === ButtonAction.REFRESH" class="button-refresh"
-              (click)="refresh()" [color]="(actionRightDef.color ? actionRightDef.color : '')" appTooltip
+              (click)="fetchLatestRefresh()" [color]="(actionRightDef.color ? actionRightDef.color : '')" appTooltip
               [title]="actionRightDef.tooltip | translate">
               <div *ngIf="ongoingAutoRefresh" class="spinner-autorefresh2">
                 <div class="loader"></div>

--- a/src/app/shared/table/table.component.ts
+++ b/src/app/shared/table/table.component.ts
@@ -280,6 +280,13 @@ export class TableComponent implements OnInit, AfterViewInit, OnDestroy {
     }
   }
 
+  public fetchLatestRefresh(autoRefresh = false) {
+    const dateRangeFilters = this.dataSource.tableFiltersDef.filter(filter => filter.type === FilterType.DATE_RANGE);
+    dateRangeFilters.forEach(filter => filter.currentValue.endDate = moment().toDate());
+    dateRangeFilters.forEach(filter => this.dataSource.filterChanged(filter));
+    this.refresh(autoRefresh);
+  }
+
   public refresh(autoRefresh = false) {
     // Start refresh
     if (!this.ongoingRefresh) {
@@ -394,7 +401,7 @@ export class TableComponent implements OnInit, AfterViewInit, OnDestroy {
       // Create the timer
       this.autoRefreshTimeout = setTimeout(() => {
         if (this.alive && !this.loading && !this.ongoingRefresh) {
-          this.refresh(true);
+          this.fetchLatestRefresh(true);
         }
       }, this.refreshIntervalSecs * 1000);
     }

--- a/src/app/shared/table/table.component.ts
+++ b/src/app/shared/table/table.component.ts
@@ -146,6 +146,9 @@ export class TableComponent implements OnInit, AfterViewInit, OnDestroy {
         startDate: event?.startDate.toDate(),
         endDate: event?.endDate.toDate()
       };
+      for (let picker of this.datePickers) {
+        picker.picker.updateCalendars();
+      }
       this.filterChanged(filterDef);
     }
   }
@@ -155,6 +158,15 @@ export class TableComponent implements OnInit, AfterViewInit, OnDestroy {
     this.dateRangeChanged(filterDef, {
       startDate: moment(splitRangeValue[0], filterDef.dateRangeTableFilterDef.locale.displayFormat),
       endDate: moment(splitRangeValue[1], filterDef.dateRangeTableFilterDef.locale.displayFormat)
+    });
+  }
+
+  public setDateRangeToLatest(filterDef: TableFilterDef) {
+    const startDate = moment(filterDef.currentValue.startDate);
+    const endDate = moment();
+    this.dateRangeChanged(filterDef, {
+      startDate,
+      endDate
     });
   }
 
@@ -282,8 +294,9 @@ export class TableComponent implements OnInit, AfterViewInit, OnDestroy {
 
   public fetchLatestRefresh(autoRefresh = false) {
     const dateRangeFilters = this.dataSource.tableFiltersDef.filter(filter => filter.type === FilterType.DATE_RANGE);
-    dateRangeFilters.forEach(filter => filter.currentValue.endDate = moment().toDate());
-    dateRangeFilters.forEach(filter => this.dataSource.filterChanged(filter));
+    for (let filter of dateRangeFilters) {
+      this.setDateRangeToLatest(filter);
+    }
     this.refresh(autoRefresh);
   }
 


### PR DESCRIPTION
When refresh button is clicked or auto refresh is enabled, latest data must be fetched. This is done by setting end date in date range filter to now value.