### PR TITLE
Filtering logs based on date time value set in URL.

### DIFF
--- a/src/app/pages/logs/list/logs-list-table-data-source.ts
+++ b/src/app/pages/logs/list/logs-list-table-data-source.ts
@@ -87,13 +87,20 @@ export class LogsListTableDataSource extends TableDataSource<Log> {
         this.filterChanged(logLevelTableFilter);
       }
     }
-    // Timestamp
-    const timestamp = this.windowService.getSearch('Timestamp');
-    if (timestamp) {
-      const startDateFilter = this.tableFiltersDef.find(filter => filter.id === 'dateFrom');
-      if (startDateFilter) {
-        startDateFilter.currentValue = moment(timestamp).toDate();
-        this.filterChanged(startDateFilter);
+    // StartDateTime and EndDateTime
+    const startDateTime = this.windowService.getSearch('StartDateTime');
+    const endDateTime = this.windowService.getSearch('EndDateTime');
+    if (startDateTime) {
+      const startDateTimeValue = moment(startDateTime);
+      let endDateTimeValue = moment(startDateTime).endOf('day');
+      if (endDateTime) {
+        endDateTimeValue = moment(endDateTime);
+      }
+      const dateRangeFilter = this.tableFiltersDef.find(filter => filter.id === 'dateRange');
+      if (dateRangeFilter) {
+        dateRangeFilter.currentValue.startDate = startDateTimeValue;
+        dateRangeFilter.currentValue.endDate = endDateTimeValue;
+        this.filterChanged(dateRangeFilter);
         const timestampColumn = this.tableColumnsDef.find(column => column.id === 'timestamp');
         if (timestampColumn) {
           this.tableColumnsDef.forEach((column) => {

--- a/src/app/pages/transactions/history/transactions-history-table-data-source.ts
+++ b/src/app/pages/transactions/history/transactions-history-table-data-source.ts
@@ -511,7 +511,7 @@ export class TransactionsHistoryTableDataSource extends TableDataSource<Transact
       case LogButtonAction.NAVIGATE_TO_LOGS:
         if (actionDef.action) {
           (actionDef as TableOpenURLActionDef).action('logs?ChargingStationID=' + transaction.chargeBoxID +
-            '&Timestamp=' + transaction.timestamp + '&LogLevel=I');
+            '&StartDateTime=' + transaction.timestamp + '&EndDateTime=' + transaction.stop.timestamp + '&LogLevel=I');
         }
         break;
       case ChargingStationButtonAction.NAVIGATE_TO_CHARGING_PLANS:

--- a/src/app/pages/transactions/in-error/transactions-in-error-table-data-source.ts
+++ b/src/app/pages/transactions/in-error/transactions-in-error-table-data-source.ts
@@ -375,7 +375,7 @@ export class TransactionsInErrorTableDataSource extends TableDataSource<Transact
       case LogButtonAction.NAVIGATE_TO_LOGS:
         if (actionDef.action) {
           (actionDef as TableOpenURLActionDef).action('logs?ChargingStationID=' + transaction.chargeBoxID +
-            '&Timestamp=' + transaction.timestamp + '&LogLevel=I');
+            '&StartDateTime=' + transaction.timestamp + '&LogLevel=I');
         }
         break;
     }

--- a/src/app/pages/transactions/in-progress/transactions-in-progress-table-data-source.ts
+++ b/src/app/pages/transactions/in-progress/transactions-in-progress-table-data-source.ts
@@ -301,7 +301,7 @@ export class TransactionsInProgressTableDataSource extends TableDataSource<Trans
       case LogButtonAction.NAVIGATE_TO_LOGS:
         if (actionDef.action) {
           (actionDef as TableOpenURLActionDef).action('logs?ChargingStationID=' + transaction.chargeBoxID +
-            '&Timestamp=' + transaction.timestamp + '&LogLevel=I');
+            '&StartDateTime=' + transaction.timestamp + '&LogLevel=I');
         }
         break;
       case ChargingStationButtonAction.NAVIGATE_TO_CHARGING_PLANS:


### PR DESCRIPTION
When navigating to logs from sessions page through clicking on action buttons, timestamp is being set instead of startDateTime and endDateTime which is used by DateRangeFilter.

1. For sessions in History, when clicked StartDateTime (logs) = Started At of session and EndDateTime (logs) = End Date of session.
2. For sessions in Progress and sessions in Error, StartDateTime (logs) = Started At of session but EndDateTime (logs) = EOD. 

