### PR TITLE
Fix for consumption chart which flickers as well as legend state being lost.

### DIFF
--- a/src/app/shared/component/consumption-chart/consumption-chart.component.ts
+++ b/src/app/shared/component/consumption-chart/consumption-chart.component.ts
@@ -125,6 +125,7 @@ export class ConsumptionChartComponent implements AfterViewInit {
   public loadAllConsumptionsChanged(matCheckboxChange: MatCheckboxChange) {
     if (matCheckboxChange) {
       this.loadAllConsumptions = matCheckboxChange.checked;
+      this.updateVisibleDatasets();
       this.refresh();
     }
   }
@@ -489,9 +490,8 @@ export class ConsumptionChartComponent implements AfterViewInit {
         duration: 0,
       },
       responsive: true,
-      maintainAspectRatio: false,
       // spanGaps: true,
-      // aspectRatio: this.ratio,
+      aspectRatio: this.ratio,
       plugins: {
         legend: {
           position: 'bottom',

--- a/src/app/shared/table/table.component.ts
+++ b/src/app/shared/table/table.component.ts
@@ -149,6 +149,7 @@ export class TableComponent implements OnInit, AfterViewInit, OnDestroy {
       };
       for (const picker of this.datePickers) {
         picker.picker.updateCalendars();
+        picker.clear();
       }
       this.filterChanged(filterDef);
     }


### PR DESCRIPTION
1. In sessions tab, select a consumption chart and check if only subset of data is being loaded initially. Data points for once every 3 minutes is loaded instead of once every minute. 
2. 