### PR TITLE
table component wrap to handle mobile

### DIFF
--- a/src/app/shared/table/table.component.html
+++ b/src/app/shared/table/table.component.html
@@ -3,7 +3,7 @@
     <!-- Toolbar -->
     <div *ngIf="dataSource.hasActions || dataSource.hasFilters || dataSource.isSearchEnabled" class="mat-toolbar">
       <!-- Actions  -->
-      <div class="left-actions d-flex flex-row mat-toolbar-row ">
+      <div class="left-actions d-flex flex-wrap flex-row mat-toolbar-row ">
         <!-- Create Left Actions -->
         <ng-container *ngFor="let actionDef of dataSource.tableActionsDef; let i=index">
           <!-- Action Button -->


### PR DESCRIPTION
**before :**

<img width="330" alt="image" src="https://user-images.githubusercontent.com/55297234/181028460-7c6c136b-713f-4a53-869e-d4bf40fc680b.png">

**after :**

<img width="327" alt="image" src="https://user-images.githubusercontent.com/55297234/181028687-defab362-91ca-4112-ac1e-3e6b33b1c1cb.png">

Works for every page that uses tables component.
Doesn't break the Web UI.
